### PR TITLE
pass mandatory minminingtxfee option to bitcoind

### DIFF
--- a/bin/bsv_oneshot
+++ b/bin/bsv_oneshot
@@ -8,4 +8,4 @@ if [ $# -gt 0 ]; then
     args=("$@")
 fi
 
-exec bitcoind -excessiveblocksize=1000000000 -maxstackmemoryusageconsensus=100000000 "${args[@]}"
+exec bitcoind -excessiveblocksize=1000000000 -maxstackmemoryusageconsensus=100000000 -minminingtxfee=0.00000500 "${args[@]}"


### PR DESCRIPTION
Running the docker container fails, with bitcoind throwing a message that minminingtxfee is required.

Found
https://github.com/bitcoin-sv/bitcoin-sv/blob/89d55a8ddb0e29f4786e11efad1e92cdefd0b9c5/doc/release-notes-v1.0.11.md?plain=1#L11

And passing the arg allows the container to run successfully.